### PR TITLE
fix(identity): block identity pages we're not actually using

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -39,14 +39,6 @@ builder.Services.Configure<IdentityOptions>(options =>
     options.Lockout.AllowedForNewUsers = true;
 });
 
-builder.Services.Configure<IdentityOptions>(options =>
-{
-    // Lockout settings.
-    options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);
-    options.Lockout.MaxFailedAccessAttempts = 5;
-    options.Lockout.AllowedForNewUsers = true;
-});
-
 // Load .env into builder.Configuration
 builder.Configuration.AddDotNetEnv();
 


### PR DESCRIPTION
Stops exposing default Identity pages we do not use, while keeping only our scaffolded Identity pages available.