### PR TITLE
fix(admin-cars): improve create flow and lookup access

### DIFF
--- a/Areas/Admin/Views/Cars/Create.cshtml
+++ b/Areas/Admin/Views/Cars/Create.cshtml
@@ -20,6 +20,15 @@
         </div>
     </div>
 
+    @if (TempData["StatusMessage"] is string statusMessage)
+    {
+        <div class="mb-12 p-6 bg-secondary-container/10 border-l-4 border-secondary text-secondary text-xs uppercase tracking-widest font-bold" role="alert">@statusMessage</div>
+    }
+    @if (TempData["ErrorMessage"] is string errorMessage)
+    {
+        <div class="mb-12 p-6 bg-error-container/10 border-l-4 border-error text-error text-xs uppercase tracking-widest font-bold" role="alert">@errorMessage</div>
+    }
+
     <!-- Inventory Workspace -->
     <div class="bg-surface-container-lowest p-10 md:p-16 border border-outline-variant/10 shadow-[0_45px_100px_rgba(0,0,0,0.08)] relative overflow-hidden">
         <div class="absolute top-0 right-0 w-96 h-96 bg-secondary/5 rounded-bl-full transform translate-x-32 -translate-y-32"></div>

--- a/Areas/Admin/Views/Cars/Index.cshtml
+++ b/Areas/Admin/Views/Cars/Index.cshtml
@@ -6,21 +6,22 @@
 
 <main class="pt-32 pb-24 max-w-7xl mx-auto px-6 md:px-12 bg-surface">
     <!-- Header -->
-    <div class="mb-16 border-b border-outline-variant/20 pb-12 flex flex-col md:flex-row justify-between items-end gap-12">
+    <div class="mb-16 border-b border-outline-variant/20 pb-12 flex flex-col lg:flex-row justify-between lg:items-end gap-12">
         <div class="max-w-xl">
             <span class="font-label text-[10px] tracking-[0.4rem] uppercase text-secondary mb-2 block">Asset Management</span>
             <h1 class="font-headline text-3xl md:text-5xl font-black tracking-tighter uppercase mb-6">Fleet Registry</h1>
             <p class="font-body text-[10px] text-on-surface-variant uppercase tracking-widest leading-loose">Comprehensive control over the LuxRentals automotive collection. Manage specifications, collection inventory, and service status.</p>
         </div>
-        <div class="flex flex-wrap gap-4 items-center justify-end">
+        <div class="w-full lg:w-auto flex flex-col gap-4">
             <div class="flex flex-col space-y-2 mr-6 text-right hidden lg:block">
                  <span class="font-label text-[9px] uppercase tracking-widest text-on-surface-variant">Global Archive</span>
                  <span class="font-headline text-2xl font-black italic">@Model.TotalCount Vehicles</span>
             </div>
-            <div class="flex gap-4">
-                <a class="flex items-center justify-center border border-on-surface/20 text-on-surface py-4 px-8 font-label text-[10px] font-bold uppercase tracking-widest hover:border-on-surface transition-all" asp-area="Admin" asp-controller="Makes" asp-action="Index">Makes</a>
-                <a class="flex items-center justify-center border border-on-surface/20 text-on-surface py-4 px-8 font-label text-[10px] font-bold uppercase tracking-widest hover:border-on-surface transition-all" asp-area="Admin" asp-controller="VehicleClasses" asp-action="Index">Classes</a>
-                <a class="flex items-center justify-center bg-black text-white py-4 px-10 font-label text-[10px] font-bold uppercase tracking-widest hover:bg-secondary transition-colors shadow-2xl" asp-area="Admin" asp-controller="Cars" asp-action="Create">Add New</a>
+            <div class="grid grid-cols-2 gap-4 w-full sm:flex sm:flex-wrap sm:justify-start lg:flex-nowrap lg:justify-end">
+                <a class="flex items-center justify-center min-w-[9rem] lg:min-w-0 border border-on-surface/20 text-on-surface py-4 px-4 sm:px-8 lg:px-6 font-label text-[10px] font-bold uppercase tracking-widest hover:border-on-surface transition-all text-center" asp-area="Admin" asp-controller="Makes" asp-action="Index">Makes</a>
+                <a class="flex items-center justify-center min-w-[9rem] lg:min-w-0 border border-on-surface/20 text-on-surface py-4 px-4 sm:px-8 lg:px-6 font-label text-[10px] font-bold uppercase tracking-widest hover:border-on-surface transition-all text-center" asp-area="Admin" asp-controller="Models" asp-action="Index">Models</a>
+                <a class="flex items-center justify-center min-w-[9rem] lg:min-w-0 border border-on-surface/20 text-on-surface py-4 px-4 sm:px-8 lg:px-6 font-label text-[10px] font-bold uppercase tracking-widest hover:border-on-surface transition-all text-center" asp-area="Admin" asp-controller="VehicleClasses" asp-action="Index">Classes</a>
+                <a class="flex items-center justify-center min-w-[9rem] lg:min-w-0 bg-black text-white py-4 px-4 sm:px-8 lg:px-6 font-label text-[10px] font-bold uppercase tracking-widest hover:bg-secondary transition-colors shadow-2xl text-center" asp-area="Admin" asp-controller="Cars" asp-action="Create">Add New</a>
             </div>
         </div>
     </div>

--- a/Areas/Admin/Views/Cars/_CarForm.cshtml
+++ b/Areas/Admin/Views/Cars/_CarForm.cshtml
@@ -1,7 +1,6 @@
 @model LuxRentals.ViewModels.Cars.Admin.CarEditVm
 
 @{
-    var returnUrl = $"{Context.Request.Path}{Context.Request.QueryString}";
     var hasBookings = Model.LockBookedCarFields;
     var lockedFieldsetState = hasBookings ? "disabled" : null;
 }
@@ -47,15 +46,6 @@
             <label asp-for="FkModelId" class="font-label text-[10px] uppercase tracking-widest text-on-surface-variant block">Manufacturer Model</label>
             <select asp-for="FkModelId" asp-items="Model.ModelOptions" class="ghost-input w-full uppercase tracking-widest text-xs cursor-pointer"></select>
             <span asp-validation-for="FkModelId" class="text-error text-[9px] uppercase font-bold"></span>
-            @if (!hasBookings)
-            {
-                <div class="pt-2 flex items-center gap-2">
-                    <span class="text-[9px] text-on-surface-variant uppercase tracking-tighter italic">Archive missing?</span>
-                    <a asp-area="Admin" asp-controller="Makes" asp-action="Index" asp-route-returnUrl="@returnUrl" class="text-[9px] text-secondary font-bold uppercase tracking-widest hover:underline">Marques</a>
-                    <span class="text-[9px] text-on-surface-variant">/</span>
-                    <a asp-area="Admin" asp-controller="Models" asp-action="Index" asp-route-returnUrl="@returnUrl" class="text-[9px] text-secondary font-bold uppercase tracking-widest hover:underline">Models</a>
-                </div>
-            }
         </div>
 
         <div class="space-y-2">
@@ -68,12 +58,6 @@
             <label asp-for="FkVehicleClassId" class="font-label text-[10px] uppercase tracking-widest text-on-surface-variant block">Asset Category</label>
             <select asp-for="FkVehicleClassId" asp-items="Model.VehicleClassOptions" class="ghost-input w-full uppercase tracking-widest text-xs cursor-pointer"></select>
             <span asp-validation-for="FkVehicleClassId" class="text-error text-[9px] uppercase font-bold"></span>
-            @if (!hasBookings)
-            {
-                <div class="pt-2">
-                    <a asp-area="Admin" asp-controller="VehicleClasses" asp-action="Index" asp-route-returnUrl="@returnUrl" class="text-[9px] text-secondary font-bold uppercase tracking-widest hover:underline italic">Segment missing? Register class here.</a>
-                </div>
-            }
         </div>
 
         <div class="space-y-2">


### PR DESCRIPTION
Removes the in-form lookup detour (e.g. "missing a make/model, click here to add one"), and adds Models to the admin cars toolbar so lookup management is still available. This means that the admin must make sure to create any makes or models before starting to create a car. But I think that's fine because the previous flow wasn't preserving any form values to begin with. This should fix the temp data issue as there are no redirects back to the main car form, but I added temp data rendering on that page too just in case. Visually, the admin cars index toolbar/header might look a bit worse, but it looks good enough to me at desktop, tablet, and mobile sizes.

For a super quick test, just hop onto this branch and look at all the car management pages (index, makes, models, classes, create/edit form). Try adding a make and model as well, that should be all thanks!